### PR TITLE
fix: overridden background-color by antd-mobile

### DIFF
--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -9,6 +9,11 @@ body {
   scroll-behavior: smooth;
 }
 
+// Fix antd-mobile body style without impacting all pages
+body {
+  --adm-color-background: var(--neutral-01);
+}
+
 .swal2-container {
   z-index: 10000 !important;
 }


### PR DESCRIPTION
### Description

The PR resolves the #307 issue, but not by following the [guidance](https://mobile.ant.design/guide/theming#theming) provided by antd-mobile. 

This is because not all pages have antd-mobile enabled, and the goal of this fix is to minimize the impact on the app.

### Related issues
- fix #307 