### PR TITLE
chore: simplify development installation process

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -12,13 +12,11 @@ Flycat is a client-side software without introducing backends or database setup.
 `Nodejs >= v18.12.1` `yarn >= 1.22.19`
 
 ```sh
-git clone https://github.com/digi-monkey/flycat-web.git --recurse-submodules
+git clone https://github.com/digi-monkey/flycat-web.git
 
-## run install script
 cd flycat-web
-./scripts/install.sh
 
-# install packages
+# install dependencies
 yarn
 
 ## development

--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "generate": "plop --plopfile internals/generators/plopfile.ts",
     "prettify": "prettier --write",
     "extract-messages": "i18next-scanner --config=internals/extractMessages/i18next-scanner.config.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preinstall": "./scripts/install.sh"
   },
   "browserslist": {
     "production": [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,23 @@
 echo "Pulling submodules..."
 git submodule update --init --recursive
 
-echo "Installing Rustup..."
-# Install Rustup (compiler)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-# Adding binaries to path
-source "$HOME/.cargo/env"
+if ! [ -x "$(command -v rustup)" ]; then
+    echo "Installing Rustup..."
+    # Install Rustup (compiler)
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    # Adding binaries to path
+    source "$HOME/.cargo/env"
+else
+    echo "Rustup is already installed."
+fi
 
-echo "Installing wasm-pack..."
-# Install wasm-pack
-curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y
+if ! [ -x "$(command -v wasm-pack)" ]; then
+    echo "Installing wasm-pack..."
+    # Install wasm-pack
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y
+else
+    echo "wasm-pack is already installed."
+fi
 
 echo "Building wasm..."
 wasm-pack build wasm/ --target web

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,3 +1,6 @@
+echo "Pulling submodules..."
+git submodule update --init --recursive
+
 echo "Installing Rustup..."
 # Install Rustup (compiler)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
The current local development installation process requires adding the `–recurse-submodules` parameter when cloning and manually executing the `install.sh` script after cloning. The purpose of this PR is to simplify this process by adding a `preinstall` script that automatically pulls submodules and executes scripts before running `yarn (install)`.