### PR TITLE
build: use lodash-es to replace lodash imports

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ const nextConfig = {
     includePaths: [path.resolve(__dirname, 'src')],
     prependData: `@import 'styles/mixin.scss';`,
   },
-  transpilePackages: ['antd-mobile'],
+  transpilePackages: ['antd-mobile', 'lodash-es'],
   async rewrites() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest-styled-components": "7.0.8",
     "js-lnurl": "0.5.1",
     "lint-staged": "12.1.7",
+    "lodash-es": "4.17.21",
     "markdown-it": "13.0.1",
     "marked": "4.3.0",
     "next": "13.2.4",
@@ -177,6 +178,7 @@
   },
   "devDependencies": {
     "@types/browser-image-compression": "1.0.9",
+    "@types/lodash-es": "4.17.12",
     "@types/marked": "4.0.8",
     "@types/react-tag-input": "6.6.1",
     "@types/sharedworker": "0.0.88",

--- a/src/components/ReactTagInput/Suggestions.jsx
+++ b/src/components/ReactTagInput/Suggestions.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash/isEqual';
-import escape from 'lodash/escape';
+import { escape, isEqual } from 'lodash-es';
 
 const maybeScrollSuggestionIntoView = (suggestionEl, suggestionsContainer) => {
   const containerHeight = suggestionsContainer.offsetHeight;

--- a/src/components/ReactTagInput/index.jsx
+++ b/src/components/ReactTagInput/index.jsx
@@ -1,9 +1,7 @@
 import React, { Component, createRef } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import isEqual from 'lodash/isEqual';
-import noop from 'lodash/noop';
-import uniq from 'lodash/uniq';
+import { isEqual, noop, uniq } from 'lodash-es';
 import ClearAllTags from './ClearAllTags';
 import Suggestions from './Suggestions';
 import PropTypes from 'prop-types';

--- a/src/components/ReactTagInput/utils.ts
+++ b/src/components/ReactTagInput/utils.ts
@@ -1,4 +1,4 @@
-import escapeRegExp from 'lodash/escapeRegExp';
+import { escapeRegExp } from 'lodash-es';
 
 /**
  * Convert an array of delimiter characters into a regular expression

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -12,7 +12,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { useMatchMobile } from 'hooks/useMediaQuery';
 import { useMyPublicKey } from 'hooks/useMyPublicKey';
 import { useCallWorker } from 'hooks/useWorker';
-import _ from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -118,7 +118,7 @@ const HomePage = ({ isLoggedIn }: HomePageProps) => {
     let msgFilter = homeMsgFilters.find(
       v => v.type === lastSelectedFilter,
     )?.filter;
-    msgFilter = msgFilter ? _.cloneDeep(msgFilter) : undefined;
+    msgFilter = msgFilter ? cloneDeep(msgFilter) : undefined;
     const isValidEvent = homeMsgFilters.find(
       v => v.type === lastSelectedFilter,
     )?.isValidEvent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,6 +2841,18 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
+"@types/lodash-es@4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.202"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+
 "@types/marked@4.0.8":
   version "4.0.8"
   resolved "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz#b316887ab3499d0a8f4c70b7bd8508f92d477955"
@@ -8521,6 +8533,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
Using lodash-es instead of lodash can reduce the size of the production bundle. 
In the future, we should avoid using ﻿import _ from 'lodash-es'. This import will bundle the entire lodash.

Before: 
![CleanShot 2023-12-13 at 17 15 57](https://github.com/digi-monkey/flycat-web/assets/9718515/a94a7b9a-10ee-494c-9d02-0e8dafbd7d2f)

After:
![CleanShot 2023-12-13 at 17 13 12](https://github.com/digi-monkey/flycat-web/assets/9718515/33e54b62-f254-492b-9cd4-cd4e077e0761)
